### PR TITLE
Fix enemy creation budget floor to account for reserved energy

### DIFF
--- a/src/shared/engine/enemy-generation/EnemyCraftExecutor.ts
+++ b/src/shared/engine/enemy-generation/EnemyCraftExecutor.ts
@@ -22,6 +22,7 @@ import type {
   CultivationTechnique,
   Skill,
 } from '@shared/types/cultivator';
+import { CREATION_RESERVED_ENERGY } from '@shared/engine/creation-v2/config/CreationBalance';
 import { getEnemyArchetype } from './EnemyArchetypeRegistry';
 import {
   DEFAULT_ENEMY_INTENT_SAFETY_PROFILE,
@@ -303,7 +304,10 @@ export class EnemyCraftExecutor {
 
     return {
       productType: intent.productType,
-      energyBudget: Math.max(12, intent.energyBudget + (archetype.energyBias ?? 0)),
+      energyBudget: Math.max(
+        CREATION_RESERVED_ENERGY[intent.productType] + 10,
+        intent.energyBudget + (archetype.energyBias ?? 0),
+      ),
       unlockScore: Math.max(0, intent.unlockScore + (archetype.unlockBias ?? 0)),
       dominantTags,
       ...(positiveTagBiases ? { positiveTagBiases } : {}),

--- a/src/shared/engine/enemy-generation/utils.ts
+++ b/src/shared/engine/enemy-generation/utils.ts
@@ -1,4 +1,5 @@
 import { ELEMENT_NAME_PREFIX } from '@shared/engine/creation-v2/config/CreationMappings';
+import { CREATION_RESERVED_ENERGY } from '@shared/engine/creation-v2/config/CreationBalance';
 import type { ElementType, EnemyRace, RealmStage, RealmType } from '@shared/types/constants';
 import {
   ATTRIBUTE_KEYS,
@@ -147,8 +148,10 @@ export function resolveEnergyBudget(
     artifact: 0.46,
   } as const;
 
+  const minByType = CREATION_RESERVED_ENERGY[productType] + 10;
+
   return Math.max(
-    12,
+    minByType,
     Math.round(
       baseByType[productType] +
         difficulty * scaleByType[productType] +


### PR DESCRIPTION
The energy budget floor (hardcoded 12) did not account for reserved energy subtracted before affix selection. For skills (reserved=3), the remaining budget of 9 was below the cheapest skill_core cost of 10, causing all core affixes to be rejected as budget_exhausted.

Use CREATION_RESERVED_ENERGY[productType] + 10 as the floor to guarantee core affix affordability after reservation.