### PR TITLE
feat: 支持用户自定义 LLM 配置

### DIFF
--- a/src/react-app/components/game-shell/gameNavigation.ts
+++ b/src/react-app/components/game-shell/gameNavigation.ts
@@ -281,6 +281,12 @@ export const gameDockGroups: GameNavGroup[] = [
         href: '/game/settings/feedback',
         expandedDockLabel: '📝 意见反馈',
       },
+      {
+        id: 'llm-config',
+        sceneLabel: '模型配置',
+        href: '/game/settings/llm-config',
+        expandedDockLabel: '⚙️ 模型配置',
+      },
     ],
   },
 ];

--- a/src/react-app/main.tsx
+++ b/src/react-app/main.tsx
@@ -4,6 +4,28 @@ import { RouterProvider } from 'react-router';
 import { router } from './router';
 import './index.css';
 
+const originalFetch = window.fetch;
+window.fetch = async (input, init) => {
+  if (typeof input === 'string' && input.startsWith('/api/')) {
+    const raw = localStorage.getItem('daoyou_llm_config');
+    if (raw) {
+      try {
+        const cfg = JSON.parse(raw);
+        const headers = new Headers(init?.headers);
+        headers.set('x-llm-provider', cfg.provider);
+        headers.set('x-llm-api-key', cfg.apiKey);
+        if (cfg.baseUrl) headers.set('x-llm-base-url', cfg.baseUrl);
+        headers.set('x-llm-model', cfg.model);
+        headers.set('x-llm-fast-model', cfg.fastModel);
+        init = { ...init, headers };
+      } catch {
+        // ignore invalid json
+      }
+    }
+  }
+  return originalFetch(input, init);
+};
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <RouterProvider router={router} />

--- a/src/react-app/router.tsx
+++ b/src/react-app/router.tsx
@@ -511,6 +511,20 @@ export const router = createBrowserRouter(
                 '意见反馈',
               )}
             />
+            <Route
+              path="settings/llm-config"
+              lazy={lazyRoute(
+                () => import('@app/routes/game/settings/llm-config/route'),
+              )}
+              handle={scene(
+                {
+                  id: 'llm-config',
+                  presentation: 'service',
+                  summary: '配置你自己的 LLM Provider 与模型参数。',
+                },
+                '模型配置',
+              )}
+            />
           </Route>
 
           <Route element={<GameCombatLayout />}>

--- a/src/react-app/routes/game/settings/llm-config/route.tsx
+++ b/src/react-app/routes/game/settings/llm-config/route.tsx
@@ -1,0 +1,216 @@
+import { GameSceneFrame } from '@app/components/game-shell';
+import { InkButton } from '@app/components/ui/InkButton';
+import { InkInput } from '@app/components/ui/InkInput';
+import { InkSelect } from '@app/components/ui/InkSelect';
+import { useState } from 'react';
+
+const STORAGE_KEY = 'daoyou_llm_config';
+
+function readStoredConfig() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return JSON.parse(raw) as Record<string, string>;
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+const PROVIDERS = [
+  { value: 'deepseek', label: 'DeepSeek' },
+  { value: 'ark', label: '火山方舟 (ARK)' },
+  { value: 'kimi', label: 'Kimi (Moonshot)' },
+  { value: 'alibaba', label: '阿里云 (Qwen)' },
+  { value: 'openrouter', label: 'OpenRouter' },
+  { value: 'openai', label: 'OpenAI / 兼容' },
+];
+
+const PROVIDER_DEFAULTS: Record<
+  string,
+  { baseUrl: string; model: string; fastModel: string }
+> = {
+  deepseek: {
+    baseUrl: 'https://api.deepseek.com',
+    model: 'deepseek-chat',
+    fastModel: 'deepseek-chat',
+  },
+  kimi: {
+    baseUrl: 'https://api.moonshot.cn/v1',
+    model: 'kimi-k2.6',
+    fastModel: 'kimi-k2.6',
+  },
+  alibaba: {
+    baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+    model: 'qwen-turbo',
+    fastModel: 'qwen-turbo',
+  },
+  openai: {
+    baseUrl: 'https://api.openai.com/v1',
+    model: 'gpt-4o',
+    fastModel: 'gpt-4o-mini',
+  },
+  openrouter: {
+    baseUrl: '',
+    model: '',
+    fastModel: '',
+  },
+  ark: {
+    baseUrl: '',
+    model: '',
+    fastModel: '',
+  },
+};
+
+export default function LlmConfigPage() {
+  const stored = readStoredConfig();
+  const [provider, setProvider] = useState(stored?.provider || 'deepseek');
+  const [apiKey, setApiKey] = useState(stored?.apiKey || '');
+  const [baseUrl, setBaseUrl] = useState(stored?.baseUrl || '');
+  const [model, setModel] = useState(stored?.model || '');
+  const [fastModel, setFastModel] = useState(stored?.fastModel || '');
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<{
+    type: 'success' | 'error';
+    text: string;
+  } | null>(null);
+  const [hasConfig, setHasConfig] = useState(!!stored);
+
+  const canSubmit =
+    provider && apiKey && model && fastModel && !loading;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+
+    setLoading(true);
+    setMessage(null);
+
+    try {
+      const config = {
+        provider,
+        apiKey,
+        baseUrl: baseUrl || undefined,
+        model,
+        fastModel,
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+      setHasConfig(true);
+      setMessage({ type: 'success', text: '配置已保存到浏览器本地。' });
+    } catch {
+      setMessage({ type: 'error', text: '保存失败，请稍后重试' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClear = () => {
+    localStorage.removeItem(STORAGE_KEY);
+    setProvider('deepseek');
+    setApiKey('');
+    setBaseUrl('');
+    setModel('');
+    setFastModel('');
+    setHasConfig(false);
+    setMessage({ type: 'success', text: '已清除本地配置，恢复为服务器默认模型。' });
+  };
+
+  return (
+    <GameSceneFrame
+      variant="lite"
+      title="模型配置"
+      description="为当前角色配置独立的 LLM Provider 与模型参数。配置保存在浏览器本地，仅当前设备生效。"
+    >
+      <div className="space-y-5">
+        <InkSelect
+          label="Provider"
+          value={provider}
+          onChange={(value) => {
+            setProvider(value);
+            const defaults = PROVIDER_DEFAULTS[value];
+            if (defaults) {
+              setBaseUrl(defaults.baseUrl);
+              setModel(defaults.model);
+              setFastModel(defaults.fastModel);
+            }
+          }}
+        >
+          {PROVIDERS.map((p) => (
+            <option key={p.value} value={p.value}>
+              {p.label}
+            </option>
+          ))}
+        </InkSelect>
+
+        <InkInput
+          label="API Key"
+          type="password"
+          placeholder="sk-..."
+          value={apiKey}
+          onChange={setApiKey}
+
+        />
+
+        <InkInput
+          label="Base URL（可选）"
+          placeholder="https://api.example.com/v1"
+          value={baseUrl}
+          onChange={setBaseUrl}
+
+        />
+
+        <InkInput
+          label="普通模型"
+          placeholder="如 deepseek-chat"
+          value={model}
+          onChange={setModel}
+
+        />
+
+        <InkInput
+          label="Fast 模型"
+          placeholder="如 deepseek-chat"
+          value={fastModel}
+          onChange={setFastModel}
+
+        />
+
+        <div className="flex flex-wrap items-center gap-3">
+          <InkButton
+            variant="primary"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+          >
+            {loading ? '保存中...' : '保存配置'}
+          </InkButton>
+
+          {hasConfig && (
+            <InkButton
+              variant="secondary"
+              onClick={handleClear}
+              disabled={loading}
+            >
+              清除配置
+            </InkButton>
+          )}
+
+          {message && (
+            <span
+              className={`text-sm ${
+                message.type === 'success' ? 'text-teal' : 'text-crimson'
+              }`}
+            >
+              {message.text}
+            </span>
+          )}
+        </div>
+
+        <div className="border-ink/10 border-t pt-4">
+          <p className="text-ink-secondary text-sm leading-6">
+            配置保存在浏览器 localStorage 中，仅当前设备生效，更换浏览器或清除缓存后需要重新配置。
+            <br />
+            API Key 仅在前端本地存储，服务端通过请求头获取并调用，不会在服务器持久化保存。
+          </p>
+        </div>
+      </div>
+    </GameSceneFrame>
+  );
+}

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -9,6 +9,27 @@ import internalRouter from '@server/routes/internal';
 const app = new Hono<AppEnv>();
 
 app.use('*', async (context, next) => runWithContext(context, next));
+
+app.use('*', async (context, next) => {
+  const provider = context.req.header('x-llm-provider');
+  const apiKey = context.req.header('x-llm-api-key');
+  const baseUrl = context.req.header('x-llm-base-url');
+  const model = context.req.header('x-llm-model');
+  const fastModel = context.req.header('x-llm-fast-model');
+
+  if (provider && apiKey && model && fastModel) {
+    context.set('llmConfig', {
+      provider,
+      apiKey,
+      baseUrl: baseUrl || null,
+      model,
+      fastModel,
+    });
+  }
+
+  await next();
+});
+
 app.all('/api/auth/*', handleAuthRequest);
 app.use('/api/*', jsonError());
 app.use('/internal/*', jsonError());

--- a/src/server/lib/auth/hono.ts
+++ b/src/server/lib/auth/hono.ts
@@ -1,6 +1,9 @@
 import { auth } from '@server/lib/auth/auth';
 import { authUsers } from '@server/lib/auth/schema';
-import { verifyTurnstileToken } from '@server/lib/auth/turnstile';
+import {
+  isTurnstileServerEnabled,
+  verifyTurnstileToken,
+} from '@server/lib/auth/turnstile';
 import { db } from '@server/lib/drizzle/db';
 import { eq } from 'drizzle-orm';
 import type { Context } from 'hono';
@@ -52,6 +55,10 @@ function authError(message: string, status = 400) {
 
 async function validateCaptcha(context: Context): Promise<Response | null> {
   if (!CAPTCHA_PROTECTED_PATHS.has(context.req.path)) {
+    return null;
+  }
+
+  if (!isTurnstileServerEnabled()) {
     return null;
   }
 

--- a/src/server/lib/drizzle/schema.ts
+++ b/src/server/lib/drizzle/schema.ts
@@ -786,3 +786,5 @@ export const creationProducts = pgTable(
     ),
   ],
 );
+
+

--- a/src/server/lib/hono/types.ts
+++ b/src/server/lib/hono/types.ts
@@ -8,6 +8,13 @@ export type AppVariables = {
   user: AuthUser;
   cultivator: ActiveCultivator;
   executor: DbExecutor;
+  llmConfig: {
+    provider: string;
+    apiKey: string;
+    baseUrl: string | null;
+    model: string;
+    fastModel: string;
+  };
   validatedJson: unknown;
   validatedQuery: unknown;
 };

--- a/src/server/utils/aiClient.ts
+++ b/src/server/utils/aiClient.ts
@@ -1,6 +1,7 @@
 import { AlibabaLanguageModelOptions, createAlibaba } from '@ai-sdk/alibaba';
 import { createDeepSeek, DeepSeekLanguageModelOptions } from '@ai-sdk/deepseek';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
+import { getCurrentContext } from '@server/lib/http/context';
 import { generateText, streamText, ToolSet } from 'ai';
 import { jsonrepair } from 'jsonrepair';
 import z from 'zod';
@@ -18,26 +19,65 @@ ${JSON.stringify(jsonSchema, null, 2)}`;
 };
 
 /**
- * 获取 DeepSeek Provider
+ * 从请求上下文读取用户自定义 LLM 配置
  */
-function getProvider() {
+export type UserLlmConfig = {
+  provider: string;
+  apiKey: string;
+  baseUrl: string | null;
+  model: string;
+  fastModel: string;
+};
+
+function getUserLlmConfig(): UserLlmConfig | undefined {
+  try {
+    const ctx = getCurrentContext();
+    return ctx.get('llmConfig');
+  } catch {
+    return undefined;
+  }
+}
+
+export type LlmOverrideConfig = {
+  provider: string;
+  apiKey: string;
+  baseUrl?: string | null;
+  model: string;
+  fastModel: string;
+};
+
+function getEffectiveProvider(
+  override?: LlmOverrideConfig,
+): string | undefined {
+  return (override ?? getUserLlmConfig())?.provider;
+}
+
+function kimiTemperature(
+  override?: LlmOverrideConfig,
+): number | undefined {
+  return getEffectiveProvider(override) === 'kimi' ? 0.6 : undefined;
+}
+
+/**
+ * 获取 Provider
+ */
+function getProvider(override?: LlmOverrideConfig) {
+  const userConfig = override ?? getUserLlmConfig();
+
+  if (userConfig) {
+    if (userConfig.provider === 'openrouter') {
+      return createOpenRouter({ apiKey: userConfig.apiKey });
+    }
+    return createDeepSeek({
+      apiKey: userConfig.apiKey,
+      baseURL: userConfig.baseUrl ?? undefined,
+    });
+  }
+
   if (process.env.PROVIDER_CHOOSE === 'ark') {
     return createDeepSeek({
       baseURL: process.env.ARK_BASE_URL,
       apiKey: process.env.ARK_API_KEY,
-      // fetch: async (url, init) => {
-      //   console.log('==== LLM REQUEST ====');
-      //   console.log('URL:', url);
-      //   console.log('HEADERS:', init?.headers);
-      //   console.log('BODY:', init?.body);
-
-      //   const res = await fetch(url, init);
-
-      //   const clone = res.clone();
-      //   console.log('==== LLM RESPONSE ====');
-      //   console.log(await clone.text());
-      //   return res;
-      // },
     });
   }
   if (process.env.PROVIDER_CHOOSE === 'kimi') {
@@ -71,8 +111,26 @@ const getArkRandomModel = () => {
 /**
  * 获取 Model 实例
  */
-export function getModel(fast: boolean = false) {
-  const provider = getProvider();
+export function getModel(
+  fast: boolean = false,
+  override?: LlmOverrideConfig,
+) {
+  const userConfig = override ?? getUserLlmConfig();
+
+  if (userConfig) {
+    const model = fast ? userConfig.fastModel : userConfig.model;
+    if (userConfig.provider === 'alibaba') {
+      const alibabaProvider = createAlibaba({
+        apiKey: userConfig.apiKey,
+        baseURL: userConfig.baseUrl ?? undefined,
+      });
+      return alibabaProvider.languageModel(model);
+    }
+    const provider = getProvider(override);
+    return provider(model);
+  }
+
+  const provider = getProvider(override);
   if (process.env.PROVIDER_CHOOSE === 'ark') {
     const model = fast ? process.env.ARK_MODEL_FAST_USE : getArkRandomModel();
     return provider(model!);
@@ -113,12 +171,15 @@ export async function text(
   prompt: string,
   userInput: string,
   fast: boolean = false,
+  override?: LlmOverrideConfig,
 ) {
-  const model = getModel(fast);
+  const model = getModel(fast, override);
+  const temperature = kimiTemperature(override);
   const res = await generateText({
     model,
     system: prompt,
     prompt: userInput,
+    ...(temperature !== undefined && { temperature }),
     providerOptions: {
       deepseek: {
         thinking: { type: 'disabled' },
@@ -142,10 +203,12 @@ export function stream_text(
   thinking: boolean = false,
 ) {
   const model = getModel(fast);
+  const temperature = kimiTemperature();
   return streamText({
     model,
     system: prompt,
     prompt: userInput,
+    ...(temperature !== undefined && { temperature }),
     onFinish: (res) => {
       console.debug('AI生成Text Stream：usage', res.usage);
     },
@@ -180,7 +243,11 @@ async function generateStructuredData<T>(
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     // 每次重试降低温度：1.0 -> 0.7 -> 0.4 (更加稳定)
-    const temperature = Math.max(0, 1 - attempt * 0.3);
+    const kimiTemp = kimiTemperature();
+    const temperature =
+      kimiTemp !== undefined
+        ? Math.max(0, kimiTemp - attempt * 0.2)
+        : Math.max(0, 1 - attempt * 0.3);
     const model = getModel(fast);
     const res = await generateText({
       model,
@@ -274,11 +341,13 @@ export async function tool(
   thinking: boolean = false,
 ) {
   const model = getModel();
+  const temperature = kimiTemperature();
   const res = await generateText({
     model,
     system: prompt,
     prompt: userInput,
     tools,
+    ...(temperature !== undefined && { temperature }),
     providerOptions: {
       deepseek: {
         thinking: { type: thinking ? 'enabled' : 'disabled' },


### PR DESCRIPTION
## 调整内容
- 前端新增模型配置页 (/game/settings/llm-config)，支持 Provider/API Key/Base URL/模型选择
- 配置保存在浏览器 localStorage，自动通过 x-llm-* 请求头传递给后端
- 后端解析请求头注入 Hono context，aiClient 优先使用用户自定义配置
- kimi 模型固定 temperature 为 0.6（API 限制）
- Turnstile 未配置时自动跳过（开发环境友好）

## UI
<img width="2188" height="1426" alt="image" src="https://github.com/user-attachments/assets/c30a5f71-96ad-4dc0-acc2-7f6343b885d2" />
