### PR TITLE
fix: accept spirit fruit in inventory resources

### DIFF
--- a/src/shared/contracts/resources.test.ts
+++ b/src/shared/contracts/resources.test.ts
@@ -111,6 +111,48 @@ describe('multi-scope resource contracts', () => {
     expect(RESOURCE_TOPIC_SCOPE_KIND['sect.membership']).toBe('cultivator');
   });
 
+  test('accepts spirit fruit consumables in inventory pages', () => {
+    expect(
+      RESOURCE_DATA_SCHEMAS['inventory.consumables'].safeParse({
+        items: [
+          {
+            id: '44444444-4444-4444-8444-444444444444',
+            name: '凝寒露果',
+            type: '丹药',
+            quality: '凡品',
+            quantity: 2,
+            description: '灵田中凝结寒露而成的灵果。',
+            prompt: '',
+            score: 0,
+            spec: {
+              kind: 'spirit_fruit',
+              family: 'cultivation',
+              operations: [
+                {
+                  type: 'gain_progress',
+                  target: 'cultivation_exp',
+                  value: 100,
+                },
+              ],
+              consumeRules: {
+                scene: 'out_of_battle_only',
+                quotaCategory: 'none',
+              },
+              source: { kind: 'spirit_field', version: 1 },
+            },
+          },
+        ],
+        pagination: {
+          page: 1,
+          pageSize: 20,
+          total: 1,
+          totalPages: 1,
+          hasMore: false,
+        },
+      }).success,
+    ).toBe(true);
+  });
+
   test('keeps infrastructure and daily construction status separate', () => {
     const infrastructure = { facilities: [] };
     const member = {

--- a/src/shared/contracts/resources/inventory.ts
+++ b/src/shared/contracts/resources/inventory.ts
@@ -525,6 +525,25 @@ export const consumableSchema = z
         .strict(),
       z
         .object({
+          kind: z.literal('spirit_fruit'),
+          family: z.enum(PILL_FAMILY_VALUES),
+          operations: z.array(conditionOperationSchema),
+          consumeRules: z
+            .object({
+              scene: z.literal('out_of_battle_only'),
+              quotaCategory: z.enum(PILL_QUOTA_CATEGORY_VALUES),
+            })
+            .strict(),
+          source: z
+            .object({
+              kind: z.literal('spirit_field'),
+              version: z.literal(1),
+            })
+            .strict(),
+        })
+        .strict(),
+      z
+        .object({
           kind: z.literal('talisman'),
           scenario: z.string(),
           sessionMode: z.enum(TALISMAN_SESSION_MODE_VALUES),


### PR DESCRIPTION
Spirit fruit is already part of ConsumableSpec, but the inventory resource Zod discriminator only accepts pill and talisman. An inventory page containing a spirit_fruit therefore fails response validation and may surface as an empty consumables bag / HTTP 500. This PR only adds the missing strict spirit_fruit contract and one resource-page regression test. Verification: bun test src/shared/contracts/resources.test.ts (18 pass); target-file ESLint; bun run build:server.